### PR TITLE
Fix bug where mic can't be changed in Firefox

### DIFF
--- a/esm/AudioInputVolumeMonitor/AudioInputVolumeMonitor.js
+++ b/esm/AudioInputVolumeMonitor/AudioInputVolumeMonitor.js
@@ -27,6 +27,7 @@ class AudioInputVolumeMonitor extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.props.device !== prevProps.device) {
+      this.stopMonitoring();
       this.initMonitoring();
     }
 

--- a/src/AudioInputVolumeMonitor/AudioInputVolumeMonitor.jsx
+++ b/src/AudioInputVolumeMonitor/AudioInputVolumeMonitor.jsx
@@ -39,6 +39,7 @@ class AudioInputVolumeMonitor extends React.Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (this.props.device !== prevProps.device) {
+      this.stopMonitoring()
       this.initMonitoring()
     }
     if (this.state.soundLevel !== prevState.soundLevel) {


### PR DESCRIPTION
Changing the mic in Firefox resulted in a "Concurrent mic process limit"
error, which is a bug in Firefox.

- https://stackoverflow.com/questions/59068146/navigator-mediadevices-getusermedia-api-rejecting-with-error-notreadableerror
- https://bugzilla.mozilla.org/show_bug.cgi?id=1238038

This PR causes the audio device to close down whenever you choose another device in the dropdown,
but ensures that the closing happens before reopening.
